### PR TITLE
Update etcd snap to 3.4.33

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,11 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - uses: actions/checkout@v2
-    - uses: jhenstridge/snapcraft-build-action@v1
+    - uses: actions/checkout@v4
+    - uses: snapcore/action-build@v1
       id: snapcraft
+      with:
+        snapcraft-channel: 7.x/stable
     - name: Test snap
       run: sudo ./test_snap.sh ${{ steps.snapcraft.outputs.snap }}
     - uses: actions/upload-artifact@v1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: etcd
-version: '3.4.22'
+version: '3.4.33'
 summary: Distributed reliable key-value store
 description: |
   Etcd is a high availability key-value store, implementing the Raft
@@ -21,9 +21,9 @@ apps:
 parts:
   etcd:
     plugin: go
-    go-channel: 1.19/stable
+    go-channel: 1.21/stable
     source: http://github.com/etcd-io/etcd.git
-    source-tag: v3.4.22
+    source-tag: v3.4.33
     override-build: |
       go build -o $SNAPCRAFT_PART_INSTALL/bin/etcd go.etcd.io/etcd
       go build -o $SNAPCRAFT_PART_INSTALL/bin/etcdctl go.etcd.io/etcd/etcdctl


### PR DESCRIPTION
## Overview
Updates the v3.4 branch to build the 3.4.33 release of etcd

## Details
* swaps to using the snapcore/action
* pins the snapcraft version to 7.x/stable in order to continue building against core18
* update the go-channel version to match [etcd's .go-version](https://github.com/etcd-io/etcd/blob/v3.4.33/.go-version)