### PR TITLE
Update etcd snap to 3.3.27

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,11 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - uses: actions/checkout@v2
-    - uses: jhenstridge/snapcraft-build-action@v1
+    - uses: actions/checkout@v4
+    - uses: snapcore/action-build@v1
       id: snapcraft
+      with:
+        snapcraft-channel: 7.x/stable
     - name: Test snap
       run: sudo ./test_snap.sh ${{ steps.snapcraft.outputs.snap }}
     - uses: actions/upload-artifact@v1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: etcd
-version: '3.3.19'
+version: '3.3.27'
 summary: Distributed reliable key-value store
 description: |
   Etcd is a high availability key-value store, implementing the Raft
@@ -23,7 +23,7 @@ parts:
     plugin: go
     go-channel: 1.12/stable
     source: http://github.com/etcd-io/etcd.git
-    source-tag: v3.3.19
+    source-tag: v3.3.27
     go-importpath: github.com/coreos/etcd
     go-packages:
       - github.com/coreos/etcd


### PR DESCRIPTION
## Overview
Updates the v3.3 branch to build the 3.3.27 release of etcd

## Details
* swaps to using the snapcore/action
* pins the snapcraft version to 7.x/stable in order to continue building against core18