### PR TITLE
Update etcd snap to 3.2.32

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build Snap
+
+# Controls when the action will run. Triggers the workflow on push to any branch
+on: push
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - uses: actions/checkout@v4
+    - uses: snapcore/action-build@v1
+      id: snapcraft
+      with:
+        snapcraft-channel: 7.x/stable
+    - name: Test snap
+      run: sudo ./test_snap.sh ${{ steps.snapcraft.outputs.snap }}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: etcd.snap
+        path: ${{ steps.snapcraft.outputs.snap }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,13 +1,14 @@
 name: etcd
-version: '3.2.17'
+version: '3.2.32'
 summary: Resilient key-value store by CoreOS
 description: |
-  Etcd is a high availability key-value store, implementing the RAFT
+  Etcd is a high availability key-value store, implementing the Raft
   algorithm to deal with failover within the etcd cluster. Popular
   as a store of small but important data in distributed systems.
 confinement: strict
 grade: stable
-
+base: core18
+ 
 # pending a fix to snapd environment variable handling
 # environment:
 #   ETCDCTL_API: 3
@@ -20,8 +21,6 @@ apps:
   etcdctl:
     command: etcdctl
     plugs: [ home, network-bind ]
-    aliases:
-      - etcdctl
 
 # You might be curious as to why we had to install golang from ppa instead of
 # using the go part in snapcraft like we used to
@@ -47,11 +46,11 @@ parts:
       apt-get -y install software-properties-common
       add-apt-repository ppa:gophers/archive
       apt-get update
-      apt-get install golang-1.10-go -y
+      apt-get install git golang-1.10-go -y
       export PATH=$PATH:/usr/lib/go-1.10/bin
       export SNAP_ROOT="$(readlink -f .)"
       export GOPATH=$SNAP_ROOT/gopath
-      git clone https://github.com/coreos/etcd.git -b v3.2.17 --depth 1
+      git clone https://github.com/coreos/etcd.git -b v3.2.32 --depth 1
       (cd etcd; ./build)
       cp -r ./etcd/bin ../install
       chmod +x ./etcd/bin/etcd


### PR DESCRIPTION
## Overview
Updates the v3.2 branch to build the 3.2.32 release of etcd

## Details
* swaps to using the snapcore/action
* pins the snapcraft version to 7.x/stable in order to continue building against core18
* update the snapcraft file to snapcraft 7.x standards by specifying core18 base
* ensure that git is installed during the build process
* the `etcdctl` alias is automatically available now
    > DEPRECATED: Aliases are now handled by the store, and shouldn't be declared in the snap.
    > See http://snapcraft.io/docs/deprecation-notices/dn5 for more information.