### PR TITLE
Update etcd snap to 3.4.35

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         snapcraft-channel: 7.x/stable
     - name: Test snap
       run: sudo ./test_snap.sh ${{ steps.snapcraft.outputs.snap }}
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: etcd.snap
         path: ${{ steps.snapcraft.outputs.snap }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: etcd
-version: '3.4.33'
+version: '3.4.35'
 summary: Distributed reliable key-value store
 description: |
   Etcd is a high availability key-value store, implementing the Raft

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,9 +21,9 @@ apps:
 parts:
   etcd:
     plugin: go
-    go-channel: 1.21/stable
+    go-channel: 1.22/stable
     source: http://github.com/etcd-io/etcd.git
-    source-tag: v3.4.33
+    source-tag: v3.4.35
     override-build: |
       go build -o $SNAPCRAFT_PART_INSTALL/bin/etcd go.etcd.io/etcd
       go build -o $SNAPCRAFT_PART_INSTALL/bin/etcdctl go.etcd.io/etcd/etcdctl


### PR DESCRIPTION
### Overview

Update etcd 3.4 patch version to 3.4.35

### Details
* update patch version
* update go version to [match upstream](https://github.com/etcd-io/etcd/commit/8aa0ba6752f3abaa2deb92951645faa5f9d779f7)
* include some CI maintenance for building the snap on Prs